### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/IoannisPAPADIMITRIOU/a5b4901f-e446-403f-838d-d0d83df95f46/b0db2513-eaa6-4d80-a743-eb2a7b03777d/_apis/work/boardbadge/1be16174-8596-4059-9e6c-44adb14d8139)](https://dev.azure.com/IoannisPAPADIMITRIOU/a5b4901f-e446-403f-838d-d0d83df95f46/_boards/board/t/b0db2513-eaa6-4d80-a743-eb2a7b03777d/Microsoft.RequirementCategory)
 # rosalind
 Rosalind framewok


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/IoannisPAPADIMITRIOU/a5b4901f-e446-403f-838d-d0d83df95f46/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.